### PR TITLE
Remove legacy "github_token" input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,6 @@ name: "Update Tag"
 description: "Update the provided tag in the Github repo"
 author: "Richard Simko"
 inputs:
-  github_token:
-    description: "Required for permission to tag the repo."
-    required: true
   tag_name:
     description: "Name of the tag to create or update"
     required: true


### PR DESCRIPTION
It got removed on https://github.com/richardsimko/github-tag-action/commit/eacaf871668382501b1d4e763b7e7db7ee0d1c2d